### PR TITLE
SB-0002: Fix layer naming in main function for Lambda services

### DIFF
--- a/main.js
+++ b/main.js
@@ -64,9 +64,9 @@ async function main() {
       "lambda-ts": false,
       "glue-python": false,
       "state-machine": false,
-      "python-layer-python": false,
-      "python-layer-js": false,
-      "python-layer-ts": false,
+      "lambda-layer-python": false,
+      "lambda-layer-js": false,
+      "lambda-layer-ts": false,
     };
 
     // Lambda
@@ -104,19 +104,19 @@ async function main() {
     } catch (_) {}
 
     // Python Layer
-    const pythonLayerDir = path.join(rootDir, "python-layer");
+    const pythonLayerDir = path.join(rootDir, "lambda-layer");
     try {
       const stats = await fs.stat(pythonLayerDir);
       if (stats.isDirectory()) {
-        result["python-layer-python"] = await scanDirectoryForExtensions(
+        result["lambda-layer-python"] = await scanDirectoryForExtensions(
           pythonLayerDir,
           EXTENSIONS.python
         );
-        result["python-layer-js"] = await scanDirectoryForExtensions(
+        result["lambda-layer-js"] = await scanDirectoryForExtensions(
           pythonLayerDir,
           EXTENSIONS.js
         );
-        result["python-layer-ts"] = await scanDirectoryForExtensions(
+        result["lambda-layer-ts"] = await scanDirectoryForExtensions(
           pythonLayerDir,
           EXTENSIONS.ts
         );


### PR DESCRIPTION
This pull request updates the naming convention and directory structure for the "python-layer" feature in `main.js` to align with a new "lambda-layer" terminology. The changes ensure consistency in key names and directory paths used throughout the code.

### Naming convention updates:
* Updated keys in the `result` object from `"python-layer-*"` to `"lambda-layer-*"` to reflect the new naming convention. (`[main.jsL67-R69](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aL67-R69)`)

### Directory structure updates:
* Changed the directory path from `python-layer` to `lambda-layer` in the `pythonLayerDir` variable and updated all related references to ensure compatibility with the new structure. (`[main.jsL107-R119](diffhunk://#diff-58417e0f781b6656949d37258c8b9052ed266e2eb7a5163cad7b0863e6b2916aL107-R119)`)